### PR TITLE
Direct end users to sensor-metadata 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # LemnaTec Fixed Metadata
 
-The XML files in this repository are used to generate fixed metadata values by the LemnaTec Field Scanalyzer system.
+The XML files in this repository are used to generate fixed metadata values by the LemnaTec Field Scanalyzer system in Maricopa, Arizona.
 
+This metadata is intended for use by the Field Scanalyzer System. The [sensor-metadata](https://github.com/terraref/sensor-metadata/)  repository contains information inteded for use in downstream data processing.
 
-Changes to these files should always be made in this Github repository and reviewed before merging.  Files are then copied to the LemnaTec control system via git. 
+Changes to these files should always be made in this Github repository and reviewed before merging.  
+Files are then copied to the LemnaTec control system via git. 


### PR DESCRIPTION
Not sure if we should direct them to https://github.com/terraref/sensor-metadata/tree/master/sensors or to the metadata on Clowder. Please advise / edit as appropriate.